### PR TITLE
Enhance site with persistent theming

### DIFF
--- a/Aeronautics.html
+++ b/Aeronautics.html
@@ -1,11 +1,25 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="Insights into Alon Kanter's aeronautics experience">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Aeronautics</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              proxima: ['Proxima nova', 'sans-serif']
+            }
+          }
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="content">
@@ -14,6 +28,7 @@
         <button class="menu-button" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">
           <img src="/img/menu-icon.png" alt="Menu Icon" class="menu-icon">
         </button>
+        <button id="theme-toggle" class="ms-3 rounded-md px-2 py-1 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800">🌙</button>
 
         <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
           <div class="offcanvas-header">
@@ -96,6 +111,22 @@
       </main>
     </div>
 
+    <button id="topButton" class="fixed bottom-5 right-5 p-3 rounded-full bg-gray-800 text-white hidden dark:bg-gray-200 dark:text-gray-800">↑</button>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script>
+      const root = document.documentElement;
+      const themeBtn = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') root.classList.add('dark');
+      themeBtn.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+      });
+      const topBtn = document.getElementById('topButton');
+      window.addEventListener('scroll', () => {
+        topBtn.classList.toggle('hidden', window.scrollY < 200);
+      });
+      topBtn.addEventListener('click', () => window.scrollTo({top:0,behavior:'smooth'}));
+    </script>
   </body>
 </html>

--- a/Contacto.html
+++ b/Contacto.html
@@ -1,11 +1,25 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="Contact Alon Kanter">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Contact</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              proxima: ['Proxima nova', 'sans-serif']
+            }
+          }
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="content">
@@ -14,6 +28,7 @@
         <button class="menu-button" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">
           <img src="/img/menu-icon.png" alt="Menu Icon" class="menu-icon">
         </button>
+        <button id="theme-toggle" class="ms-3 rounded-md px-2 py-1 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800">🌙</button>
 
         <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
           <div class="offcanvas-header">
@@ -106,6 +121,8 @@
       </main>
     </div>
 
+    <button id="topButton" class="fixed bottom-5 right-5 p-3 rounded-full bg-gray-800 text-white hidden dark:bg-gray-200 dark:text-gray-800">↑</button>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>
       // Custom validation script
@@ -120,6 +137,19 @@
           }
         }
       }, true);
+      const root = document.documentElement;
+      const themeBtn = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') root.classList.add('dark');
+      themeBtn.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+      });
+      const topBtn = document.getElementById('topButton');
+      window.addEventListener('scroll', () => {
+        topBtn.classList.toggle('hidden', window.scrollY < 200);
+      });
+      topBtn.addEventListener('click', () => window.scrollTo({top:0,behavior:'smooth'}));
     </script>
   </body>
 </html>

--- a/Leadership.html
+++ b/Leadership.html
@@ -1,11 +1,25 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="Leadership journey of Alon Kanter">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Leadership</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              proxima: ['Proxima nova', 'sans-serif']
+            }
+          }
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="content">
@@ -14,6 +28,7 @@
         <button class="menu-button" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">
           <img src="/img/menu-icon.png" alt="Menu Icon" class="menu-icon">
         </button>
+        <button id="theme-toggle" class="ms-3 rounded-md px-2 py-1 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800">🌙</button>
 
         <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
           <div class="offcanvas-header">
@@ -184,6 +199,22 @@
       </main>
     </div>
 
+    <button id="topButton" class="fixed bottom-5 right-5 p-3 rounded-full bg-gray-800 text-white hidden dark:bg-gray-200 dark:text-gray-800">↑</button>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script>
+      const root = document.documentElement;
+      const themeBtn = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') root.classList.add('dark');
+      themeBtn.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+      });
+      const topBtn = document.getElementById('topButton');
+      window.addEventListener('scroll', () => {
+        topBtn.classList.toggle('hidden', window.scrollY < 200);
+      });
+      topBtn.addEventListener('click', () => window.scrollTo({top:0,behavior:'smooth'}));
+    </script>
   </body>
 </html>

--- a/Programming.html
+++ b/Programming.html
@@ -1,11 +1,25 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="Alon Kanter's programming projects portfolio">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Programming Projects</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              proxima: ['Proxima nova', 'sans-serif']
+            }
+          }
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="content">
@@ -14,6 +28,7 @@
         <button class="menu-button" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">
           <img src="/img/menu-icon.png" alt="Menu Icon" class="menu-icon">
         </button>
+        <button id="theme-toggle" class="ms-3 rounded-md px-2 py-1 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800">🌙</button>
 
         <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
           <div class="offcanvas-header">
@@ -128,6 +143,22 @@
         </section>
     </div>
 
+    <button id="topButton" class="fixed bottom-5 right-5 p-3 rounded-full bg-gray-800 text-white hidden dark:bg-gray-200 dark:text-gray-800">↑</button>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script>
+      const root = document.documentElement;
+      const themeBtn = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark') root.classList.add('dark');
+      themeBtn.addEventListener('click', () => {
+        root.classList.toggle('dark');
+        localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+      });
+      const topBtn = document.getElementById('topButton');
+      window.addEventListener('scroll', () => {
+        topBtn.classList.toggle('hidden', window.scrollY < 200);
+      });
+      topBtn.addEventListener('click', () => window.scrollTo({top:0,behavior:'smooth'}));
+    </script>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Bootstrap-Portfolio
+# Bootstrap Portfolio
+
+This portfolio demonstrates a modern responsive design using TailwindCSS.
+It includes a persistent dark mode toggle and a scroll‑to‑top button on every page.

--- a/index.html
+++ b/index.html
@@ -1,24 +1,39 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8">
+    <meta name="description" content="Alon Kanter's portfolio showcasing programming, aeronautics and leadership projects">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              proxima: ['Proxima nova', 'sans-serif']
+            }
+          }
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="content">
-      <header class="full-screen">
-        <div class="overlay">
-          <h1>Alon Kanter</h1>
+      <header class="relative h-screen bg-cover bg-center" style="background-image: url('img/imagen header.jpeg');">
+        <div class="absolute inset-0 bg-black/60 flex items-center justify-center">
+          <h1 class="text-5xl md:text-7xl font-bold font-proxima">Alon Kanter</h1>
         </div>
       </header>
-      <header class="header-fijo">
+      <header class="header-fijo bg-white/80 dark:bg-gray-800/70 backdrop-blur-md">
         <p class="header-text">Alon Kanter</p>
         <button class="menu-button" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">
           <img src="/img/menu-icon.png" alt="Menu Icon" class="menu-icon">
         </button>
+        <button id="theme-toggle" class="ms-3 rounded-md px-2 py-1 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800">🌙</button>
 
         <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
           <div class="offcanvas-header">
@@ -34,9 +49,6 @@
           </div>
         </div>
       </header>
-
-     
-    </header>
     <main>
       <section>
         <div class="container text-center mt-5">
@@ -307,6 +319,22 @@
     </main>
   </div>
 
+  <button id="topButton" class="fixed bottom-5 right-5 p-3 rounded-full bg-gray-800 text-white hidden dark:bg-gray-200 dark:text-gray-800">↑</button>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-</body>
+  <script>
+    const root = document.documentElement;
+    const themeBtn = document.getElementById('theme-toggle');
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') root.classList.add('dark');
+    themeBtn.addEventListener('click', () => {
+      root.classList.toggle('dark');
+      localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+    });
+    const topBtn = document.getElementById('topButton');
+    window.addEventListener('scroll', () => {
+      topBtn.classList.toggle('hidden', window.scrollY < 200);
+    });
+    topBtn.addEventListener('click', () => window.scrollTo({top:0,behavior:'smooth'}));
+  </script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -23,7 +23,6 @@ body, html {
     margin: 0;
     padding: 0;
     height: 100%;
-    background-color: black;
     scroll-behavior: smooth;
 }
 
@@ -57,7 +56,6 @@ body, html {
     justify-content: space-between;
     align-items: center;
     padding: 15px 30px;
-    background-color: rgba(255, 255, 255, 0.814);
     position: sticky;
     top: 0;
     z-index: 1000; /* Asegúrate de que el header esté por encima de otros elementos */
@@ -203,5 +201,9 @@ body::-webkit-scrollbar {
 
     height: 100%;
     object-fit: cover;
+}
+
+#topButton {
+    transition: opacity 0.3s;
 }
 


### PR DESCRIPTION
## Summary
- add meta descriptions and fix header structure
- implement persistent dark mode with localStorage
- introduce a floating scroll-to-top button
- document the new features in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fde430c883318c6a88190bd57cad